### PR TITLE
Gem failing without Base64 import

### DIFF
--- a/aescrypt.gemspec
+++ b/aescrypt.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.name          = "aescrypt"
   gem.require_paths = ["lib"]
-  gem.version       = "1.0.0"
+  gem.version       = "1.0.1"
 
   gem.add_development_dependency "rake"
 end

--- a/lib/aescrypt.rb
+++ b/lib/aescrypt.rb
@@ -27,6 +27,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'openssl'
+require 'base64'
 
 module AESCrypt
   def self.encrypt(message, password)


### PR DESCRIPTION
```
NameError - uninitialized constant AESCrypt::Base64:
    /Users/jameswomack/.rbenv/versions/2.0.0-preview2/lib/ruby/gems/2.0.0/gems/aescrypt-1.0.0/lib/aescrypt.rb:38:in `decrypt'
```
