### PR TITLE
Fix namespace issue with base64

### DIFF
--- a/aescrypt.gemspec
+++ b/aescrypt.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.name          = "aescrypt"
   gem.require_paths = ["lib"]
-  gem.version       = "1.0.1"
+  gem.version       = "1.0.2"
 
   gem.add_development_dependency "rake"
 end

--- a/lib/aescrypt.rb
+++ b/lib/aescrypt.rb
@@ -31,16 +31,16 @@ require 'base64'
 
 module AESCrypt
   def self.encrypt(message, password)
-    Base64.encode64(self.encrypt_data(message.to_s.strip, self.key_digest(password), nil, "AES-256-CBC"))
+    ::Base64.encode64(self.encrypt_data(message.to_s.strip, self.key_digest(password), nil, "AES-256-CBC"))
   end
 
   def self.decrypt(message, password)
-    base64_decoded = Base64.decode64(message.to_s.strip)
+    base64_decoded = ::Base64.decode64(message.to_s.strip)
     self.decrypt_data(base64_decoded, self.key_digest(password), nil, "AES-256-CBC")
   end
 
   def self.key_digest(password)
-    OpenSSL::Digest::SHA256.new(password).digest
+    ::OpenSSL::Digest::SHA256.new(password).digest
   end
 
   # Decrypts a block of data (encrypted_data) given an encryption key
@@ -55,7 +55,7 @@ module AESCrypt
   #:arg: iv => String
   #:arg: cipher_type => String
   def self.decrypt_data(encrypted_data, key, iv, cipher_type)
-    aes = OpenSSL::Cipher::Cipher.new(cipher_type)
+    aes = ::OpenSSL::Cipher::Cipher.new(cipher_type)
     aes.decrypt
     aes.key = key
     aes.iv = iv if iv != nil
@@ -74,7 +74,7 @@ module AESCrypt
   #:arg: iv => String
   #:arg: cipher_type => String  
   def self.encrypt_data(data, key, iv, cipher_type)
-    aes = OpenSSL::Cipher::Cipher.new(cipher_type)
+    aes = ::OpenSSL::Cipher::Cipher.new(cipher_type)
     aes.encrypt
     aes.key = key
     aes.iv = iv if iv != nil


### PR DESCRIPTION
There was an issue with Base64 being interpreted as a part of AESCrypt instead of its own class:

```
token = AESCrypt.encrypt(message, password)
    NameError: uninitialized constant AESCrypt::Base64
```

All I added was the scope resolution operator.
